### PR TITLE
chore(npm): allow Webpack to import source file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+import {logger, logLevels} from './src/logger';
+
+export {
+	logger,
+	logLevels
+};
+
+export default logger;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reduct/logger",
   "description": "General logger utility for the browser and console.",
-  "main": "dist/logger.js",
+  "main": "index.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "browserify src/logger.js -o dist/logger.js --standalone reduct.loggerPackage -t [ babelify --presets [ es2015 ] ]",

--- a/src/logger.js
+++ b/src/logger.js
@@ -200,3 +200,5 @@ export {
 	logger,
 	logLevels
 };
+
+export default logger;


### PR DESCRIPTION
This PR allows Webpack to take source code and optimise it when building its tree of modules.
Prevents from the "This seems to be a pre-built javascript file. [...]" Webpack warning message in the CLI.
